### PR TITLE
Fix MLST module command syntax

### DIFF
--- a/modules/005_mlst.nf
+++ b/modules/005_mlst.nf
@@ -7,7 +7,7 @@ process MLST {
     tuple val(sample_id), path(assembly_dir)  
     
     output:
-    tuple val(sample_id), path("mlst_output/${sample_id}_mlst.tsv"),
+    tuple val(sample_id), path("mlst_output/${sample_id}_mlst.tsv")
     path("mlst_output/mlst_summary.tsv")
 
     script:
@@ -15,7 +15,7 @@ process MLST {
     mkdir -p mlst_output
 
     # Define the correct FASTA file path using Nextflow's variable expansion
-    mlst "${assembly_dir}/assembly.fasta" > mlst_output/${sample_id}_mlst.tsv --threads 3
+    mlst --threads 3 "${assembly_dir}/assembly.fasta" > mlst_output/${sample_id}_mlst.tsv
 
     # Append to summary file
     if [[ ! -s mlst_output/mlst_summary.tsv ]]; then


### PR DESCRIPTION
## Summary
- Correct mlst invocation to place `--threads` before output redirection
- Clean output specification formatting in MLST module

## Testing
- `nextflow -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da3f09e888332b7b486bda380b5dc